### PR TITLE
BUGFIX/MINOR(ntp): Fix the use of tags `install` and `configure`

### DIFF
--- a/tasks/clock-rhel-6.yml
+++ b/tasks/clock-rhel-6.yml
@@ -2,9 +2,11 @@
 - name: Check if clock file exists.
   stat: path=/etc/sysconfig/clock
   register: clock_file
+  tags: configure
 
 - name: Create clock file if it doesn't exist.
   template:
     src: clock.j2
     dest: /etc/sysconfig/clock
   when: clock_file.stat.exists == false
+  tags: configure

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"
+  tags:
+    - install
+    - configure
 
 - name: Ensure NTP-related packages are installed.
   package:
@@ -10,6 +13,7 @@
   until: install_packages is success
   retries: 5
   delay: 2
+  tags: install
 
 - name: Ensure tzdata package is installed (Linux).
   package:
@@ -20,14 +24,17 @@
   until: install_packages_tz is success
   retries: 5
   delay: 2
+  tags: install
 
 - include_tasks: clock-rhel-6.yml
   when: ansible_os_family == 'RedHat' and ansible_distribution_version.split('.')[0] == '6'
+  tags: configure
 
 - name: Set timezone
   timezone:
     name: "{{ ntp_timezone }}"
   when: ntp_manage_timezone
+  tags: configure
 
 - name: Ensure NTP is running and enabled as configured.
   service:
@@ -35,6 +42,7 @@
     state: started
     enabled: yes
   when: ntp_enabled
+  tags: configure
 
 - name: Ensure NTP is stopped and disabled as configured.
   service:
@@ -42,6 +50,7 @@
     state: stopped
     enabled: no
   when: not ntp_enabled
+  tags: configure
 
 - name: Generate ntp.conf file
   template:
@@ -49,3 +58,4 @@
     dest: /etc/ntp.conf
   notify: restart ntp
   when: ntp_manage_config
+  tags: configure


### PR DESCRIPTION
 ##### SUMMARY

It can be useful to prepare images to run only the `install` tag and then only the` configure` tag

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION